### PR TITLE
improve editor save error feedback

### DIFF
--- a/scripts/apps/editor/editor_manager.js
+++ b/scripts/apps/editor/editor_manager.js
@@ -306,7 +306,10 @@ window.EditorManager = class EditorManager extends App {
               ),
             }
         );
-        if (saveResult.success && (await FileSystemManager.save())) {
+        const fsSaveResult = saveResult.success
+            ? await FileSystemManager.save()
+            : { success: false };
+        if (saveResult.success && fsSaveResult.success) {
           this.state.originalContent = currentContent;
           this.state.isDirty = false;
           this.ui.updateDirtyStatus(false);
@@ -315,9 +318,11 @@ window.EditorManager = class EditorManager extends App {
             await this.state.onSaveCallback(savePath);
           }
         } else {
-          this.ui.updateStatusMessage(
-              `Error: ${saveResult.error || "Failed to save file system."}`
-          );
+          const errorMessage =
+              saveResult.error?.message ||
+              fsSaveResult.error?.message ||
+              "Failed to save file system.";
+          this.ui.updateStatusMessage(`Error: ${errorMessage}`);
         }
       },
       onExitRequest: this.exit.bind(this),

--- a/scripts/commands/command_base.js
+++ b/scripts/commands/command_base.js
@@ -194,7 +194,7 @@ class Command {
             }
 
             const pathArg = args[index];
-            const pathValidationResult = FileSystemManager.validatePath(pathArg, rule.options || {});
+            const pathValidationResult = await FileSystemManager.validatePath(pathArg, rule.options || {});
 
             if (!pathValidationResult.success) {
                 return ErrorHandler.createError(pathValidationResult.error);


### PR DESCRIPTION
## Summary
- ensure editor displays human-readable error messages when saving files
- verify both file creation and filesystem persistence succeed before marking save

## Testing
- `npm test` *(fails: Invalid package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893f593b23083319261a18a2df9145e