### PR TITLE
Fix command discovery for executor

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -17,7 +17,16 @@ class CommandExecutor:
 
     def _discover_commands(self):
         """Dynamically finds all available command modules."""
-        # ... (this function remains the same) ...
+        commands_dir = os.path.join(os.path.dirname(__file__), 'commands')
+        try:
+            files = os.listdir(commands_dir)
+        except FileNotFoundError:
+            return []
+        return sorted(
+            f[:-3]
+            for f in files
+            if f.endswith('.py') and f != '__init__.py'
+        )
 
     def set_context(self, user_context, users, user_groups, config, groups, jobs, ai_manager, api_key):
         """Sets the current user and system context from the JS side."""


### PR DESCRIPTION
## Summary
- implement dynamic discovery of Python command modules so command list is not undefined during Pyodide init

## Testing
- `npm test` *(fails: Error: No test files found: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6896ab20d1088331b34b22899a214644